### PR TITLE
Make idris-py compile using the latest Idris version

### DIFF
--- a/idris-python.cabal
+++ b/idris-python.cabal
@@ -11,7 +11,7 @@ Executable idris-codegen-python
   Main-is:        Main.hs
   hs-source-dirs: src
 
-  Build-depends:  idris
+  Build-depends:  idris >= 1.1 && < 1.2
                 , base
                 , containers
                 , directory

--- a/src/IRTS/CodegenPython.hs
+++ b/src/IRTS/CodegenPython.hs
@@ -468,7 +468,7 @@ cgTailCall argNames args = do
     return $ cgError "unreachable due to tail call"
 
 cgExp :: Bool -> DExp -> CG Expr
-cgExp tailPos (DV var) = return $ cgVar var
+cgExp tailPos (DV var) = return $ cgVar (Glob var)
 cgExp tailPos (DApp tc n args) = do
     tag <- ctorTag n
     case tag of
@@ -491,13 +491,13 @@ cgExp tailPos (DC _ tag n args)
 
 -- if the scrutinee is something big, save it into a variable
 -- because we'll copy it into a possibly long chain of if-elif-...
-cgExp tailPos (DCase caseType (DV var) alts) = cgCase tailPos var alts
+cgExp tailPos (DCase caseType (DV var) alts) = cgCase tailPos (Glob var) alts
 cgExp tailPos (DCase caseType e alts) = do
     scrutinee <- fresh
     emit . cgAssign scrutinee =<< cgExp False e
     cgCase tailPos scrutinee alts
 
-cgExp tailPos (DChkCase (DV var) alts) = cgCase tailPos var alts
+cgExp tailPos (DChkCase (DV var) alts) = cgCase tailPos (Glob var) alts
 cgExp tailPos (DChkCase e alts) = do
     scrutinee <- fresh
     emit . cgAssign scrutinee =<< cgExp False e

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,6 +5,7 @@ import Idris.AbsSyntax
 import Idris.ElabDecls
 import Idris.REPL
 import Idris.Main
+import Idris.Options
 
 import IRTS.Compiler
 import IRTS.CodegenPython

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.9
+resolver: lts-9.0
 
 packages:
   - location: .
@@ -12,8 +12,10 @@ flags:
     GMP: true
 
 extra-deps:
-  - libffi-0.1
-  - trifecta-1.6
+#  - libffi-0.1
+#  - trifecta-1.6
+   - binary-0.8.5.1
+   - cheapskate-0.1.1
   
 nix:
   enable: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,8 +12,6 @@ flags:
     GMP: true
 
 extra-deps:
-#  - libffi-0.1
-#  - trifecta-1.6
    - binary-0.8.5.1
    - cheapskate-0.1.1
   


### PR DESCRIPTION
I've fixed the code so it compiles with the latest Idris versions (currently 1.11). Basically the `DExp` `DV` constructor no longer carries a `LVar`. Now it carries a `Name`, so I had to wrap it into `Glob`s.

Also the `IBCFormat` constructor is now in the `Idris.Options` module, so that had to be imported too.